### PR TITLE
Add option to show content

### DIFF
--- a/djangocms_inline_comment/cms_plugins.py
+++ b/djangocms_inline_comment/cms_plugins.py
@@ -1,8 +1,11 @@
 from django.utils.translation import ugettext_lazy as _
 
-from cms.plugin_base import CMSPluginBase
+from cms.plugin_base import CMSPluginBase, PluginMenuItem
 from cms.plugin_pool import plugin_pool
-
+from cms.utils.urlutils import admin_reverse
+from django.conf.urls import url
+from django.http import HttpResponseForbidden, HttpResponseBadRequest, HttpResponse
+from django.middleware.csrf import get_token
 from djangocms_inline_comment.models import InlineComment
 
 
@@ -11,6 +14,41 @@ class InlineCommentPlugin(CMSPluginBase):
     name = _("Inline comment")
     render_template = "djangocms_inline_comment/inline_comment.html"
     allow_children = True
+
+    def get_extra_local_plugin_menu_items(self, request, plugin):
+        return [
+            PluginMenuItem(
+                _("Hide contents (currently visible)") if plugin.show_contents else _("Show contents (currently hidden)"),
+                admin_reverse("djangocms_inline_comment_change_show_contents"),
+                data={
+                    'plugin_id': plugin.pk,
+                    'show_contents': '0' if plugin.show_contents else '1',
+                    'csrfmiddlewaretoken': get_token(request),
+                },
+            )
+        ]
+
+    def get_plugin_urls(self):
+        return [
+            url(r'^change_show_contents/$', self.change_show_contents, name='djangocms_inline_comment_change_show_contents'),
+        ]
+
+    def change_show_contents(self, request):
+        if not request.user.is_staff:
+            return HttpResponseForbidden("not enough privileges")
+        if not 'plugin_id' in request.POST or not 'show_contents' in request.POST:
+            return HttpResponseBadRequest("plugin_id and show_contents POST parameter missing.")
+        plugin = None
+        if 'plugin_id' in request.POST:
+            pk = request.POST['plugin_id']
+            try:
+                plugin = self.model.objects.get(pk=pk)
+            except CMSPlugin.DoesNotExist:
+                return HttpResponseBadRequest("plugin with id %s not found." % pk)
+        show_contents = bool(int(request.POST['show_contents']))
+        plugin.show_contents = show_contents
+        plugin.save(update_fields=['show_contents'])
+        return HttpResponse("ok")
 
 
 plugin_pool.register_plugin(InlineCommentPlugin)

--- a/djangocms_inline_comment/migrations/0002_inlinecomment_show_contents.py
+++ b/djangocms_inline_comment/migrations/0002_inlinecomment_show_contents.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('djangocms_inline_comment', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='inlinecomment',
+            name='show_contents',
+            field=models.BooleanField(default=False, verbose_name='Show Contents'),
+        ),
+    ]

--- a/djangocms_inline_comment/models.py
+++ b/djangocms_inline_comment/models.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.db import models
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
 
@@ -20,6 +21,7 @@ def _get_html_field_class():
 
 class InlineComment(CMSPlugin):
     body = _get_html_field_class()(_("Comment"), null=True, blank=True)
+    show_contents = models.BooleanField(_("Show Contents"), default=False)
 
     def get_short_description(self):
         if not self.body:

--- a/djangocms_inline_comment/templates/djangocms_inline_comment/inline_comment.html
+++ b/djangocms_inline_comment/templates/djangocms_inline_comment/inline_comment.html
@@ -1,16 +1,26 @@
-{% load sekizai_tags cms_tags %}{% if request.toolbar.edit_mode %}
-{# Code is only rendered in edit mode #}
+{% load sekizai_tags cms_tags %}
 
-{% comment %} CMS needs render_plugin to be called, but the plugins should not be
-anywhere in the page. So we use a sekizai block which is never rendered {% endcomment %}
-{% addtoblock "null" %}
-<div class="plugin parent">
+{% if request.toolbar.edit_mode %}
+    {% include 'djangocms_inline_comment/inline_comment_style.html' %}
+{% endif %}
+
+{% if request.toolbar.edit_mode and not instance.show_contents %}
+    {# Code is only rendered in edit mode #}
+
+    {% comment %} CMS needs render_plugin to be called, but the plugins should not be
+    anywhere in the page. So we use a sekizai block which is never rendered {% endcomment %}
+    {% addtoblock "null" %}
+    <div class="plugin parent">
+        {% for plugin in instance.child_plugin_instances %}
+            {% render_plugin plugin %}
+        {% endfor %}
+    </div>
+    {% endaddtoblock "null" %}
+
+    {% addtoblock "css" %}
+    {% endaddtoblock %}
+{% elif instance.show_contents %}
     {% for plugin in instance.child_plugin_instances %}
         {% render_plugin plugin %}
     {% endfor %}
-</div>
-{% endaddtoblock "null" %}
-
-{% addtoblock "css" %}
-{% include 'djangocms_inline_comment/inline_comment_style.html' %}
-{% endaddtoblock %}{% endif %}
+{% endif %}

--- a/djangocms_inline_comment/templates/djangocms_inline_comment/inline_comment_style.html
+++ b/djangocms_inline_comment/templates/djangocms_inline_comment/inline_comment_style.html
@@ -3,7 +3,11 @@
 <style>
     /* Styles for inline comment draggable */
     div.cms .cms-structure .cms-draggable-{{ instance.pk|unlocalize }} > .cms-dragitem {
-        background: transparent;
+        {% if instance.show_contents %}
+            opacity: 0.6;
+        {% else %}
+            background: transparent;
+        {% endif %}
     }
 
     .cms-draggable-{{ instance.pk|unlocalize }} > .cms-dragitem > .cms-dragitem-text > strong {
@@ -16,6 +20,6 @@
 
     /* Styles for other plugins' draggables nested inside */
     div.cms .cms-structure .cms-draggable-{{ instance.pk|unlocalize }} .cms-dragitem-text {
-        opacity: 0.7;
+        opacity: 0.6;
     }
 </style>


### PR DESCRIPTION
## WIP: do not merge yet
_This is an experimental PR that still has many open questions._

Adds the option to keep the content inside the comment plugin visible.

Use cases:

* Toggle visibility of blocks of content without having to move plugins 
  in and out of the inline comment plugin.
* Add a textual inline comment to a block of content that is visible on
  the page.

<img width="931" alt="screen shot 2017-04-14 at 23 08 10" src="https://cloud.githubusercontent.com/assets/14330/25056157/5b3f16ec-2167-11e7-872c-9905b466d68c.png">

- [ ] The plugin template now has a bunch of whitespace in it. I think it makes the template much more readable. I can make it more compact again, if requested.
- [ ] I'm not sure about the styling yet. And should we add an indicator in the text of the plugin to show if it is hidden or visible? **starting with django-cms 3.5 the method used to style won't work anymore**
- [ ] Translations
- [x] Add shortcut to toggle visibility into the plugins hamburger menu
- [ ] Update tests

<img width="933" alt="screen shot 2017-04-14 at 23 54 57" src="https://cloud.githubusercontent.com/assets/14330/25057239/47aeb6f8-216e-11e7-8602-1edf9e91d371.png">

- [ ] Figure out text/icon for quick visibility toggle in hamburger menu
